### PR TITLE
Updated ext.kotlin_version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The current version of kotlin doesn't work with the newest version of flutter and it has to be changed manually.